### PR TITLE
Some Dependencies errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ root@kali:~# apt-get install python3-pip
 ```
 root@kali:~# cd GyoiThon
 root@kali:~/GyoiThon# pip3 install -r requirements.txt
+root@kali:~/GyoiThon# apt install python3-tk
 ```
 
 4. Edit config.ini of GyoiThon.  

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pysocks==1.6.7
 urllib3==1.23
 Scrapy==1.5.0
 google-api-python-client==1.7.4
+metplotlib>=3.0.3 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ urllib3==1.23
 Scrapy==1.5.0
 google-api-python-client==1.7.4
 metplotlib>=3.0.3 
+networkx>=2.2


### PR DESCRIPTION
Solves the following error on Lubuntu 18.04:

Traceback (most recent call last):
  File "gyoithon.py", line 27, in <module>
    from modules.Gyoi_Creator import Creator
  File "/home/user/development/GyoiThon/modules/Gyoi_Creator.py", line 13, in <module>
    import matplotlib.pyplot as plt
ModuleNotFoundError: No module named 'matplotlib'

Also solves this error:

ModuleNotFoundError: No module named 'networkx'
and
ModuleNotFoundError: No module named 'tkinter'